### PR TITLE
Add getCarry and getBorrow operations

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -39,7 +39,6 @@ jobs:
           --file results.json \
           --branch '${{ github.head_ref || github.ref_name }}' \
           --testbed "${MATRIX_OS}-${PLATFORM}-${CPU}-${NIM_VERSION}" \
-          --err \
           --threshold-measure latency \
           --threshold-test t_test \
           --threshold-lower-boundary _ \

--- a/benchmarks/latency/add.nim
+++ b/benchmarks/latency/add.nim
@@ -11,9 +11,13 @@ proc runLatencySaturating() {.noinline.} =
 proc runLatencyCarrying() {.noinline.} =
   benchTypesAndImpls(benchLatencyCarrying, carryingAdd)
 
+proc runLatencyFlag() {.noinline.} =
+  benchTypesAndImpls(benchLatencyFlag, carry)
+
 when isMainModule:
   echo "\n# Latency, Addition"
 
   runLatencyOverflowing()
   runLatencySaturating()
   runLatencyCarrying()
+  runLatencyFlag()

--- a/benchmarks/latency/sub.nim
+++ b/benchmarks/latency/sub.nim
@@ -11,9 +11,13 @@ proc runLatencySaturating() {.noinline.} =
 proc runLatencyCarrying() {.noinline.} =
   benchTypesAndImpls(benchLatencyCarrying, borrowingSub)
 
+proc runLatencyFlag() {.noinline.} =
+  benchTypesAndImpls(benchLatencyFlag, borrow)
+
 when isMainModule:
   echo "\n# Latency, Subtraction"
 
   runLatencyOverflowing()
   runLatencySaturating()
   runLatencyCarrying()
+  runLatencyFlag()

--- a/benchmarks/throughput/add.nim
+++ b/benchmarks/throughput/add.nim
@@ -11,9 +11,13 @@ proc runThroughputSaturating() {.noinline.} =
 proc runThroughputCarrying() {.noinline.} =
   benchTypesAndImpls(benchThroughputCarrying, carryingAdd)
 
+proc runThroughputFlag() {.noinline.} =
+  benchTypesAndImpls(benchThroughputFlag, carry)
+
 when isMainModule:
   echo "\n# Throughput, Addition"
 
   runThroughputOverflowing()
   runThroughputSaturating()
   runThroughputCarrying()
+  runThroughputFlag()

--- a/benchmarks/throughput/sub.nim
+++ b/benchmarks/throughput/sub.nim
@@ -11,9 +11,13 @@ proc runThroughputSaturating() {.noinline.} =
 proc runThroughputCarrying() {.noinline.} =
   benchTypesAndImpls(benchThroughputCarrying, borrowingSub)
 
+proc runThroughputFlag() {.noinline.} =
+  benchTypesAndImpls(benchThroughputFlag, carry)
+
 when isMainModule:
   echo "\n# Throughput, Subtraction"
 
   runThroughputOverflowing()
   runThroughputSaturating()
   runThroughputCarrying()
+  runThroughputFlag()

--- a/benchmarks/utils.nim
+++ b/benchmarks/utils.nim
@@ -211,6 +211,19 @@ template benchLatencyCarrying*(typ: typedesc, op: untyped) =
     do:
       doNotOptimize(flush)
 
+template benchLatencyFlag*(typ: typedesc, op: untyped) =
+  let opName = astToStr(op)
+
+  when not compiles op(default(typ), default(typ), false):
+    echo alignLeft(opName, 35), " -"
+  else:
+    measureLatency(typ, opName):
+      var carry {.inject.}: bool
+    do:
+      carry = op(inputsA[idx], inputsB[idx], carry)
+    do:
+      doNotOptimize(carry)
+
 template benchThroughputOverflowing*(typ: typedesc, op: untyped) =
   let opName = astToStr(op)
 

--- a/benchmarks/utils.nim
+++ b/benchmarks/utils.nim
@@ -267,7 +267,21 @@ template benchThroughputCarrying*(typ: typedesc, op: untyped) =
     measureThroughput(typ, opName):
       var flush {.inject.}: typ
     do:
-      let (res, _) = op(inputsA[idx], inputsB[idx], boolInputs[idx])
-      flush = flush xor res
+      let (res, carry) = op(inputsA[idx], inputsB[idx], boolInputs[idx])
+      flush = flush xor res xor typ(carry)
+    do:
+      doNotOptimize(flush)
+
+template benchThroughputFlag*(typ: typedesc, op: untyped) =
+  let opName = astToStr(op)
+
+  when not compiles op(default(typ), default(typ), false):
+    echo alignLeft(opName, 35), " -"
+  else:
+    measureThroughput(typ, opName):
+      var flush {.inject.}: bool
+    do:
+      let carry = op(inputsA[idx], inputsB[idx], boolInputs[idx])
+      flush = flush xor carry
     do:
       doNotOptimize(flush)

--- a/book/src/contrib/ops.md
+++ b/book/src/contrib/ops.md
@@ -59,15 +59,7 @@ template carryingAdd*(a, b: uint64, carryIn: bool): tuple[res: uint64, carryOut:
 
 ## Adding New Operations
 
-### Proxy Operations
-
-Proxy operation is an operation that offers an alternative interface for another operation. For example, [`getCarry`](/apidocs/intops/ops/add.html#getCarry.t,T,T,bool) is just sugar around [`carryingAdd`](/apidocs/intops/ops/add.html#carryingAdd.t,int32,int32,bool).
-
-To add a proxy operation, just add a dispatcher for it and put its logic right into it. Since this logic is trivial, it doesn't break our architecture of splitting implementations from dispatching.
-
-### Independent Operations
-
-Adding an independent operation means doing two things:
+Adding an operation means doing two things:
 
 1. **Adding a pure Nim implementation for the new operation.** Pure Nim implementations are universal fallbacks for all operations because they are guaranteed to compile everwhere Nim code can compile regardless of the environment. Pure Nim implementations are defined in `intops/impl/pure.nim`.
 1. **Adding a dispatcher that exposes this implementation.** Find the corresponding module in `intops/ops` (or create a new one) and add the dispatcher there.

--- a/book/src/contrib/ops.md
+++ b/book/src/contrib/ops.md
@@ -11,18 +11,18 @@ For example, `carryingAdd` mentioned in [Quickstart](../quickstart.html) is a di
 Let's examine the code of this dispatcher:
 
 ```nim
-template carryingAdd*(a, b: uint64, carryIn: bool): tuple[res: uint64, carryOut: bool] =
+template carryingAdd*(a, b: uint64, carry: bool): tuple[res: uint64, carry: bool] =
   when nimvm:
-    pure.carryingAdd(a, b, carryIn)
+    pure.carryingAdd(a, b, carry)
   else:
     when cpuX86 and compilerMsvc and canUseIntrinsics:
-      intrinsics.x86.carryingAdd(a, b, carryIn)
+      intrinsics.x86.carryingAdd(a, b, carry)
     elif compilerGccCompatible and canUseIntrinsics:
-      intrinsics.gcc.carryingAdd(a, b, carryIn)
+      intrinsics.gcc.carryingAdd(a, b, carry)
     elif cpu64Bit and compilerGccCompatible and canUseInlineC:
-      inlinec.carryingAdd(a, b, carryIn)
+      inlinec.carryingAdd(a, b, carry)
     else:
-      pure.carryingAdd(a, b, carryIn)
+      pure.carryingAdd(a, b, carry)
 ```
 
 As you can see, this dispatcher is just a nested `when`-condition that checks if:
@@ -40,21 +40,21 @@ In the dispatchers, you can use the global constants defined in `intops/consts.n
 For example, if you want to prioritize inline C implementation over intrinsics, you could modify the dispatcher like so:
 
 ```diff
-template carryingAdd*(a, b: uint64, carryIn: bool): tuple[res: uint64, carryOut: bool] =
+template carryingAdd*(a, b: uint64, carry: bool): tuple[res: uint64, carry: bool] =
   when nimvm:
-    pure.carryingAdd(a, b, carryIn)
+    pure.carryingAdd(a, b, carry)
   else:
 -   when cpuX86 and compilerMsvc and canUseIntrinsics:
 +   when cpu64Bit and compilerGccCompatible and canUseInlineC:
-+     inlinec.carryingAdd(a, b, carryIn)
++     inlinec.carryingAdd(a, b, carry)
 +   elif cpuX86 and compilerMsvc and canUseIntrinsics:
-      intrinsics.x86.carryingAdd(a, b, carryIn)
+      intrinsics.x86.carryingAdd(a, b, carry)
     elif compilerGccCompatible and canUseIntrinsics:
-      intrinsics.gcc.carryingAdd(a, b, carryIn)
+      intrinsics.gcc.carryingAdd(a, b, carry)
 -   elif cpu64Bit and compilerGccCompatible and canUseInlineC:
--     inlinec.carryingAdd(a, b, carryIn)
+-     inlinec.carryingAdd(a, b, carry)
     else:
-      pure.carryingAdd(a, b, carryIn)
+      pure.carryingAdd(a, b, carry)
 ```
 
 ## Adding New Operations

--- a/book/src/contrib/ops.md
+++ b/book/src/contrib/ops.md
@@ -25,7 +25,7 @@ template carryingAdd*(a, b: uint64, carryIn: bool): tuple[res: uint64, carryOut:
       pure.carryingAdd(a, b, carryIn)
 ```
 
-As you can see, a dispatcher is just a nested `when`-condition that checks if:
+As you can see, this dispatcher is just a nested `when`-condition that checks if:
 
 1. the operation called during compilation (`when nimvm`)
 1. the code is run on a particular CPU (`when cpuX86`) and with a particular C compiler (`and compilerMsvc`)
@@ -59,7 +59,15 @@ template carryingAdd*(a, b: uint64, carryIn: bool): tuple[res: uint64, carryOut:
 
 ## Adding New Operations
 
-Adding an operation means doing two things:
+### Proxy Operations
+
+Proxy operation is an operation that offers an alternative interface for another operation. For example, [`getCarry`](/apidocs/intops/ops/add.html#getCarry.t,T,T,bool) is just sugar around [`carryingAdd`](/apidocs/intops/ops/add.html#carryingAdd.t,int32,int32,bool).
+
+To add a proxy operation, just add a dispatcher for it and put its logic right into it. Since this logic is trivial, it doesn't break our architecture of splitting implementations from dispatching.
+
+### Independent Operations
+
+Adding an independent operation means doing two things:
 
 1. **Adding a pure Nim implementation for the new operation.** Pure Nim implementations are universal fallbacks for all operations because they are guaranteed to compile everwhere Nim code can compile regardless of the environment. Pure Nim implementations are defined in `intops/impl/pure.nim`.
 1. **Adding a dispatcher that exposes this implementation.** Find the corresponding module in `intops/ops` (or create a new one) and add the dispatcher there.

--- a/book/src/contrib/ops.md
+++ b/book/src/contrib/ops.md
@@ -64,7 +64,7 @@ Adding an operation means doing two things:
 1. **Adding a pure Nim implementation for the new operation.** Pure Nim implementations are universal fallbacks for all operations because they are guaranteed to compile everwhere Nim code can compile regardless of the environment. Pure Nim implementations are defined in `intops/impl/pure.nim`.
 1. **Adding a dispatcher that exposes this implementation.** Find the corresponding module in `intops/ops` (or create a new one) and add the dispatcher there.
 
-For example, let's define a new addition flavor called **magic addition** which adds two uint64 integers and adds the number 42 to the sum (this is our magic component).
+For example, let's define a new addition flavor called **magic addition** which adds two uint64 integers and adds the number 42 to the sum (aka the magic component).
 
 1. In `intops/impl/pure.nim`:
 
@@ -77,7 +77,12 @@ func magicAdd*(a, b: uint64): uint64 =
 
 ```nim
 template magicAdd*(a, b: uint64): uint64 =
-  ## Docstring is mandatory for dispatchers.
+  ##[ Magic addition.
+
+  Takes two integers and returns their sum plus a magic value.
+
+  Docstrings are mandatory for dispatchers! This is our public API and it must be documented.
+  ]##
 
   pure.magicAdd(a, b)
 ```

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -57,7 +57,7 @@ echo carryingAdd(12'u64, 34'u64, false)
 Output:
 
 ```nim
-(res: 46, carryOut: false)
+(res: 46, carry: false)
 ```
 
 `intops.carryingAdd` is a _dispatcher_. When invoked, it calls the best implementation of this operation out of the available ones for the given environment.

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@
 - [t]—test suite improvement
 - [d]—docs improvement
 
+## 1.0.8 (WIP)
+
+- [+] Ops: add: Added getCarry operation that does carrying addition but returns only the carry flag (#22).
+- [+] Ops: sub: Added borrowingSub operation that does borrowing subtraction but returns only the borrow flag (#22).
+
 ## 1.0.7 (February 2, 2026)
 
 - [f] Ops: composite: Added missing imports that prevented individual import of `intops/ops/composite` (#23).

--- a/changelog.md
+++ b/changelog.md
@@ -9,8 +9,8 @@
 
 ## 1.0.8 (WIP)
 
-- [+] Ops: add: Added getCarry operation that does carrying addition but returns only the carry flag (#22).
-- [+] Ops: sub: Added borrowingSub operation that does borrowing subtraction but returns only the borrow flag (#22).
+- [+] Ops: add: Added `carry` operation that does carrying addition but returns only the carry flag (#22).
+- [+] Ops: sub: Added `borrow` operation that does borrowing subtraction but returns only the borrow flag (#22).
 
 ## 1.0.7 (February 2, 2026)
 

--- a/src/intops/impl/inlineasm/x86.nim
+++ b/src/intops/impl/inlineasm/x86.nim
@@ -18,7 +18,7 @@ when cpu64Bit and cpuX86 and compilerGccCompatible and canUseInlineAsm:
     var
       sum = a
       cOut {.noinit.}: uint8
-      cInVal = if carry: 1'u64 else: 0'u64
+      cInVal = uint64(carry)
 
     asm """
       negq %[cInVal]      /* Sets CF=1 if cInVal==1, CF=0 if cInVal==0 */

--- a/src/intops/impl/inlineasm/x86.nim
+++ b/src/intops/impl/inlineasm/x86.nim
@@ -14,11 +14,11 @@ import ../../consts
 when cpu64Bit and cpuX86 and compilerGccCompatible and canUseInlineAsm:
   {.push raises: [], inline, noinit, gcsafe.}
 
-  func carryingAdd*(a, b: uint64, carryIn: bool): (uint64, bool) =
+  func carryingAdd*(a, b: uint64, carry: bool): (uint64, bool) =
     var
       sum = a
       cOut {.noinit.}: uint8
-      cInVal = if carryIn: 1'u64 else: 0'u64
+      cInVal = if carry: 1'u64 else: 0'u64
 
     asm """
       negq %[cInVal]      /* Sets CF=1 if cInVal==1, CF=0 if cInVal==0 */
@@ -31,14 +31,14 @@ when cpu64Bit and cpuX86 and compilerGccCompatible and canUseInlineAsm:
     """
     (sum, cOut > 0)
 
-  func carryingAdd*(a, b: int64, carryIn: bool): (int64, bool) =
+  func carryingAdd*(a, b: int64, carry: bool): (int64, bool) =
     var
       sum = a
       didOverflow {.noinit.}: uint8
-      cInVal = if carryIn: 1'u64 else: 0'u64
+      cInVal = if carry: 1'u64 else: 0'u64
 
     asm """
-      negq %[cInVal]      /* Sets CF based on carryIn (Standard trick) */
+      negq %[cInVal]      /* Sets CF based on carry (Standard trick) */
       adcq %[b], %[sum]   /* Signed addition is binary-identical to unsigned */
       seto %[didOverflow] /* Check OVERFLOW Flag (OF) instead of Carry */
 
@@ -104,11 +104,11 @@ when cpu64Bit and cpuX86 and compilerGccCompatible and canUseInlineAsm:
 
 when cpuX86 and compilerGccCompatible and canUseInlineAsm:
   {.push raises: [], inline, noinit, gcsafe.}
-  func carryingAdd*(a, b: uint32, carryIn: bool): (uint32, bool) =
+  func carryingAdd*(a, b: uint32, carry: bool): (uint32, bool) =
     var
       sum = a
       cOut {.noinit.}: uint8
-      cInVal = if carryIn: 1'u32 else: 0'u32
+      cInVal = if carry: 1'u32 else: 0'u32
 
     asm """
       negl %[cInVal]      /* 32-bit Negate */
@@ -121,11 +121,11 @@ when cpuX86 and compilerGccCompatible and canUseInlineAsm:
     """
     (sum, cOut > 0)
 
-  func carryingAdd*(a, b: int32, carryIn: bool): (int32, bool) =
+  func carryingAdd*(a, b: int32, carry: bool): (int32, bool) =
     var
       sum = a
       didOverflow {.noinit.}: uint8
-      cInVal = if carryIn: 1'u32 else: 0'u32
+      cInVal = if carry: 1'u32 else: 0'u32
 
     asm """
       negl %[cInVal]

--- a/src/intops/impl/inlineasm/x86.nim
+++ b/src/intops/impl/inlineasm/x86.nim
@@ -48,11 +48,11 @@ when cpu64Bit and cpuX86 and compilerGccCompatible and canUseInlineAsm:
     """
     (sum, didOverflow > 0)
 
-  func borrowingSub*(a, b: uint64, borrowIn: bool): (uint64, bool) =
+  func borrowingSub*(a, b: uint64, borrow: bool): (uint64, bool) =
     var
       diff = a
       bOut {.noinit.}: uint8
-      bInVal = if borrowIn: 1'u64 else: 0'u64
+      bInVal = if borrow: 1'u64 else: 0'u64
 
     asm """
       negq %[bInVal]      /* Sets CF=1 if bInVal==1, CF=0 if bInVal==0 */
@@ -65,14 +65,14 @@ when cpu64Bit and cpuX86 and compilerGccCompatible and canUseInlineAsm:
     """
     (diff, bOut > 0)
 
-  func borrowingSub*(a, b: int64, borrowIn: bool): (int64, bool) =
+  func borrowingSub*(a, b: int64, borrow: bool): (int64, bool) =
     var
       diff = a
       didOverflow {.noinit.}: uint8
-      bInVal = if borrowIn: 1'u64 else: 0'u64
+      bInVal = if borrow: 1'u64 else: 0'u64
 
     asm """
-      negq %[bInVal]      /* Prime CF based on borrowIn */
+      negq %[bInVal]      /* Prime CF based on borrow */
       sbbq %[b], %[diff]  /* Signed subtraction is binary-identical to unsigned */
       seto %[didOverflow] /* Check OVERFLOW Flag (OF) for signed result validity */
 
@@ -138,11 +138,11 @@ when cpuX86 and compilerGccCompatible and canUseInlineAsm:
     """
     (sum, didOverflow > 0)
 
-  func borrowingSub*(a, b: uint32, borrowIn: bool): (uint32, bool) =
+  func borrowingSub*(a, b: uint32, borrow: bool): (uint32, bool) =
     var
       diff = a
       bOut {.noinit.}: uint8
-      bInVal = if borrowIn: 1'u32 else: 0'u32
+      bInVal = if borrow: 1'u32 else: 0'u32
 
     asm """
       negl %[bInVal]      /* 32-bit Negate to set CF */
@@ -155,11 +155,11 @@ when cpuX86 and compilerGccCompatible and canUseInlineAsm:
     """
     (diff, bOut > 0)
 
-  func borrowingSub*(a, b: int32, borrowIn: bool): (int32, bool) =
+  func borrowingSub*(a, b: int32, borrow: bool): (int32, bool) =
     var
       diff = a
       didOverflow {.noinit.}: uint8
-      bInVal = if borrowIn: 1'u32 else: 0'u32
+      bInVal = if borrow: 1'u32 else: 0'u32
 
     asm """
       negl %[bInVal]

--- a/src/intops/impl/inlineasm/x86.nim
+++ b/src/intops/impl/inlineasm/x86.nim
@@ -35,7 +35,7 @@ when cpu64Bit and cpuX86 and compilerGccCompatible and canUseInlineAsm:
     var
       sum = a
       didOverflow {.noinit.}: uint8
-      cInVal = if carry: 1'u64 else: 0'u64
+      cInVal = uint64(carry)
 
     asm """
       negq %[cInVal]      /* Sets CF based on carry (Standard trick) */
@@ -52,7 +52,7 @@ when cpu64Bit and cpuX86 and compilerGccCompatible and canUseInlineAsm:
     var
       diff = a
       bOut {.noinit.}: uint8
-      bInVal = if borrow: 1'u64 else: 0'u64
+      bInVal = uint64(borrow)
 
     asm """
       negq %[bInVal]      /* Sets CF=1 if bInVal==1, CF=0 if bInVal==0 */
@@ -69,7 +69,7 @@ when cpu64Bit and cpuX86 and compilerGccCompatible and canUseInlineAsm:
     var
       diff = a
       didOverflow {.noinit.}: uint8
-      bInVal = if borrow: 1'u64 else: 0'u64
+      bInVal = uint64(borrow)
 
     asm """
       negq %[bInVal]      /* Prime CF based on borrow */
@@ -108,7 +108,7 @@ when cpuX86 and compilerGccCompatible and canUseInlineAsm:
     var
       sum = a
       cOut {.noinit.}: uint8
-      cInVal = if carry: 1'u32 else: 0'u32
+      cInVal = uint32(carry)
 
     asm """
       negl %[cInVal]      /* 32-bit Negate */
@@ -125,7 +125,7 @@ when cpuX86 and compilerGccCompatible and canUseInlineAsm:
     var
       sum = a
       didOverflow {.noinit.}: uint8
-      cInVal = if carry: 1'u32 else: 0'u32
+      cInVal = uint32(carry)
 
     asm """
       negl %[cInVal]
@@ -142,7 +142,7 @@ when cpuX86 and compilerGccCompatible and canUseInlineAsm:
     var
       diff = a
       bOut {.noinit.}: uint8
-      bInVal = if borrow: 1'u32 else: 0'u32
+      bInVal = uint32(borrow)
 
     asm """
       negl %[bInVal]      /* 32-bit Negate to set CF */
@@ -159,7 +159,7 @@ when cpuX86 and compilerGccCompatible and canUseInlineAsm:
     var
       diff = a
       didOverflow {.noinit.}: uint8
-      bInVal = if borrow: 1'u32 else: 0'u32
+      bInVal = uint32(borrow)
 
     asm """
       negl %[bInVal]

--- a/src/intops/impl/inlinec.nim
+++ b/src/intops/impl/inlinec.nim
@@ -37,11 +37,11 @@ when cpu64Bit and compilerGccCompatible and canUseInlineC:
 
     (sum, cOut > 0)
 
-  func borrowingSub*(a, b: uint64, borrowIn: bool): (uint64, bool) =
+  func borrowingSub*(a, b: uint64, borrow: bool): (uint64, bool) =
     var
       diff {.noinit.}: uint64
       bOut {.noinit.}: uint64
-      bInVal = if borrowIn: 1'u64 else: 0'u64
+      bInVal = if borrow: 1'u64 else: 0'u64
 
     {.
       emit: """

--- a/src/intops/impl/inlinec.nim
+++ b/src/intops/impl/inlinec.nim
@@ -18,7 +18,7 @@ when cpu64Bit and compilerGccCompatible and canUseInlineC:
     var
       sum {.noinit.}: uint64
       cOut {.noinit.}: uint64
-      cInVal = if carry: 1'u64 else: 0'u64
+      cInVal = uint64(carry)
 
     {.
       emit: """
@@ -41,7 +41,7 @@ when cpu64Bit and compilerGccCompatible and canUseInlineC:
     var
       diff {.noinit.}: uint64
       bOut {.noinit.}: uint64
-      bInVal = if borrow: 1'u64 else: 0'u64
+      bInVal = uint64(borrow)
 
     {.
       emit: """

--- a/src/intops/impl/inlinec.nim
+++ b/src/intops/impl/inlinec.nim
@@ -14,15 +14,14 @@ import ../consts
 when cpu64Bit and compilerGccCompatible and canUseInlineC:
   {.push raises: [], inline, noinit, gcsafe.}
 
-  func carryingAdd*(a, b: uint64, carryIn: bool): (uint64, bool) =
+  func carryingAdd*(a, b: uint64, carry: bool): (uint64, bool) =
     var
       sum {.noinit.}: uint64
       cOut {.noinit.}: uint64
-      cInVal = if carryIn: 1'u64 else: 0'u64
+      cInVal = if carry: 1'u64 else: 0'u64
 
     {.
-      emit:
-        """
+      emit: """
       /* 1. Cast inputs to 128-bit and add */
       unsigned __int128 res = ((unsigned __int128)`a`) + 
                               ((unsigned __int128)`b`) + 
@@ -45,8 +44,7 @@ when cpu64Bit and compilerGccCompatible and canUseInlineC:
       bInVal = if borrowIn: 1'u64 else: 0'u64
 
     {.
-      emit:
-        """
+      emit: """
         /* 1. Cast inputs to 128-bit and subtract */
         /* If (a < b + borrow), 'res' wraps to a very large value (high bits become 1s) */
         unsigned __int128 res = ((unsigned __int128)`a`) -
@@ -68,8 +66,7 @@ when cpu64Bit and compilerGccCompatible and canUseInlineC:
     var hi, lo {.noinit.}: uint64
 
     {.
-      emit:
-        """
+      emit: """
       /* 1. Cast inputs to 128-bit and multiply */
       unsigned __int128 res = ((unsigned __int128)`a`) * ((unsigned __int128)`b`);
   
@@ -89,8 +86,7 @@ when cpu64Bit and compilerGccCompatible and canUseInlineC:
       lo {.noinit.}: uint64
 
     {.
-      emit:
-        """
+      emit: """
       /* 1. Cast inputs to native C __int128 (Signed) */
       __int128 res = ((__int128)`a`) * ((__int128)`b`);
 
@@ -107,8 +103,7 @@ when cpu64Bit and compilerGccCompatible and canUseInlineC:
   func wideningMulAdd*(a, b, c: uint64): (uint64, uint64) =
     var hi, lo {.noinit.}: uint64
     {.
-      emit:
-        """
+      emit: """
       typedef unsigned __int128 u128;
 
       // Calculate a * b + c using 128-bit precision
@@ -124,8 +119,7 @@ when cpu64Bit and compilerGccCompatible and canUseInlineC:
   func wideningMulAdd*(a, b, c, d: uint64): (uint64, uint64) =
     var hi, lo {.noinit.}: uint64
     {.
-      emit:
-        """
+      emit: """
       typedef unsigned __int128 u128;
 
       // Calculate a * b + c + d using 128-bit precision
@@ -142,8 +136,7 @@ when cpu64Bit and compilerGccCompatible and canUseInlineC:
     var q, r {.noinit.}: uint64
 
     {.
-      emit:
-        """
+      emit: """
       typedef unsigned __int128 u128;
 
       // Construct 128-bit integer from high/low parts

--- a/src/intops/impl/intrinsics/gcc.nim
+++ b/src/intops/impl/intrinsics/gcc.nim
@@ -63,6 +63,11 @@ when compilerGccCompatible and canUseIntrinsics:
 
     (final, c1 or c2)
 
+  func carry*[T: SomeInteger](a, b: T, carry: bool): bool =
+    let (res, didOverflow) = gcc.overflowingAdd(a, b)
+
+    didOverflow or (carry and (res == high(T)))
+
   func overflowingSub*[T: SomeInteger](a, b: T): (T, bool) =
     var res {.noinit.}: T
 

--- a/src/intops/impl/intrinsics/gcc.nim
+++ b/src/intops/impl/intrinsics/gcc.nim
@@ -54,12 +54,12 @@ when compilerGccCompatible and canUseIntrinsics:
 
     res
 
-  func carryingAdd*[T: SomeInteger](a, b: T, carryIn: bool): (T, bool) =
+  func carryingAdd*[T: SomeInteger](a, b: T, carry: bool): (T, bool) =
     var t1, final {.noinit.}: T
 
     let
       c1 = builtinOverflowingAdd(a, b, t1)
-      c2 = builtinOverflowingAdd(t1, T(carryIn), final)
+      c2 = builtinOverflowingAdd(t1, T(carry), final)
 
     (final, c1 or c2)
 

--- a/src/intops/impl/intrinsics/gcc.nim
+++ b/src/intops/impl/intrinsics/gcc.nim
@@ -64,7 +64,9 @@ when compilerGccCompatible and canUseIntrinsics:
     (final, c1 or c2)
 
   func carry*[T: SomeInteger](a, b: T, carry: bool): bool =
-    let (res, didOverflow) = gcc.overflowingAdd(a, b)
+    var res {.noinit.}: T
+
+    let didOverflow = builtinOverflowingAdd(a, b, res)
 
     didOverflow or (carry and (res == high(T)))
 
@@ -106,3 +108,10 @@ when compilerGccCompatible and canUseIntrinsics:
       b2 = builtinOverflowingSub(t1, T(borrow), final)
 
     (final, b1 or b2)
+
+  func borrow*[T: SomeInteger](a, b: T, borrow: bool): bool =
+    var res {.noinit.}: T
+
+    let didBorrow = builtinOverflowingSub(a, b, res)
+
+    didBorrow or (borrow and (res == low(T)))

--- a/src/intops/impl/intrinsics/gcc.nim
+++ b/src/intops/impl/intrinsics/gcc.nim
@@ -93,11 +93,11 @@ when compilerGccCompatible and canUseIntrinsics:
 
     res
 
-  func borrowingSub*[T: SomeInteger](a, b: T, borrowIn: bool): (T, bool) =
+  func borrowingSub*[T: SomeInteger](a, b: T, borrow: bool): (T, bool) =
     var t1, final {.noinit.}: T
 
     let
       b1 = builtinOverflowingSub(a, b, t1)
-      b2 = builtinOverflowingSub(t1, T(borrowIn), final)
+      b2 = builtinOverflowingSub(t1, T(borrow), final)
 
     (final, b1 or b2)

--- a/src/intops/impl/intrinsics/x86.nim
+++ b/src/intops/impl/intrinsics/x86.nim
@@ -30,10 +30,10 @@ when cpuX86 and canUseIntrinsics:
   func carryingAdd*(a, b: uint32, carry: bool): (uint32, bool) =
     var res {.noinit.}: uint32
 
-    let carryOut =
+    let carry =
       builtinCarryingAdd(uint8(carry), cuint(a), cuint(b), cast[ptr cuint](addr res))
 
-    (res, bool(carryOut))
+    (res, bool(carry))
 
   func borrowingSub*(a, b: uint32, borrowIn: bool): (uint32, bool) =
     var res {.noinit.}: uint32
@@ -58,11 +58,11 @@ when cpu64bit and cpuX86 and canUseIntrinsics:
   func carryingAdd*(a, b: uint64, carry: bool): (uint64, bool) =
     var res {.noinit.}: uint64
 
-    let carryOut = builtinCarryingAdd(
+    let carry = builtinCarryingAdd(
       uint8(carry), culonglong(a), culonglong(b), cast[ptr culonglong](addr res)
     )
 
-    (res, bool(carryOut))
+    (res, bool(carry))
 
   func borrowingSub*(a, b: uint64, borrowIn: bool): (uint64, bool) =
     var res {.noinit.}: uint64
@@ -95,14 +95,14 @@ when cpu64bit and cpuX86 and compilerMsvc and canUseIntrinsics:
   func wideningMulAdd*(a, b, c: uint64): (uint64, uint64) =
     var
       hi, lo {.noinit.}: uint64
-      carryOut {.noinit.}: uint8
+      carry {.noinit.}: uint8
 
     lo = builtinWideningMul(culonglong(a), culonglong(b), cast[ptr culonglong](addr hi))
-    carryOut = builtinAddCarry(
+    carry = builtinAddCarry(
       0'u8, culonglong(lo), culongculong(c), cast[prt culonglong](addr lo)
     )
     discard builtinAddCarry(
-      carryOut, culonglong(hi), culonglong(0), cast[ptr culonglong](addr hi)
+      carry, culonglong(hi), culonglong(0), cast[ptr culonglong](addr hi)
     )
 
     (hi, lo)
@@ -110,21 +110,21 @@ when cpu64bit and cpuX86 and compilerMsvc and canUseIntrinsics:
   func wideningMulAdd*(a, b, c, d: uint64): (uint64, uint64) =
     var
       hi, lo {.noinit.}: uint64
-      carryOut1 {.noinit.}: uint8
-      carryOut2 {.noinit.}: uint8
+      carry1 {.noinit.}: uint8
+      carry2 {.noinit.}: uint8
 
     lo = builtinWideningMul(culonglong(a), culonglong(b), cast[ptr culonglong](addr hi))
-    carryOut1 = builtinAddCarry(
+    carry1 = builtinAddCarry(
       0'u8, culonglong(lo), culongculong(c), cast[prt culonglong](addr lo)
     )
     discard builtinAddCarry(
-      carryOut1, culonglong(hi), culonglong(0), cast[ptr culonglong](addr hi)
+      carry1, culonglong(hi), culonglong(0), cast[ptr culonglong](addr hi)
     )
-    carryOut2 = builtinAddCarry(
+    carry2 = builtinAddCarry(
       0'u8, culonglong(lo), culongculong(d), cast[prt culonglong](addr lo)
     )
     discard builtinAddCarry(
-      carryOut2, culonglong(hi), culonglong(0), cast[ptr culonglong](addr hi)
+      carry2, culonglong(hi), culonglong(0), cast[ptr culonglong](addr hi)
     )
 
     (hi, lo)

--- a/src/intops/impl/intrinsics/x86.nim
+++ b/src/intops/impl/intrinsics/x86.nim
@@ -35,6 +35,13 @@ when cpuX86 and canUseIntrinsics:
 
     (res, bool(carry))
 
+  func carry*(a, b: uint32, carry: bool): bool =
+    var res {.noinit.}: cuint
+
+    let carry = builtinCarryingAdd(uint8(carry), cuint(a), cuint(b), addr res)
+
+    bool(carry)
+
   func borrowingSub*(a, b: uint32, borrow: bool): (uint32, bool) =
     var res {.noinit.}: uint32
 
@@ -42,6 +49,13 @@ when cpuX86 and canUseIntrinsics:
       builtinBorrowingSub(uint8(borrow), cuint(a), cuint(b), cast[ptr cuint](addr res))
 
     (res, bool(borrow))
+
+  func borrow*(a, b: uint32, borrow: bool): bool =
+    var res {.noinit.}: cuint
+
+    let borrow = builtinBorrowingSub(uint8(borrow), cuint(a), cuint(b), addr res)
+
+    bool(borrow)
 
 when cpu64bit and cpuX86 and canUseIntrinsics:
   func builtinCarryingAdd*(
@@ -63,6 +77,13 @@ when cpu64bit and cpuX86 and canUseIntrinsics:
 
     (res, bool(carry))
 
+  func carry*(a, b: uint64, carry: bool): bool =
+    var res {.noinit.}: culonglong
+
+    let carry = builtinCarryingAdd(uint8(carry), culonglong(a), culonglong(b), addr res)
+
+    bool(carry)
+
   func borrowingSub*(a, b: uint64, borrow: bool): (uint64, bool) =
     var res {.noinit.}: uint64
 
@@ -71,6 +92,14 @@ when cpu64bit and cpuX86 and canUseIntrinsics:
     )
 
     (res, bool(borrow))
+
+  func borrow*(a, b: uint64, borrow: bool): bool =
+    var res {.noinit.}: culonglong
+
+    let borrow =
+      builtinBorrowingSub(uint8(borrow), culonglong(a), culonglong(b), addr res)
+
+    bool(borrow)
 
 when cpu64bit and cpuX86 and compilerMsvc and canUseIntrinsics:
   func builtinWideningMul*(

--- a/src/intops/impl/intrinsics/x86.nim
+++ b/src/intops/impl/intrinsics/x86.nim
@@ -18,7 +18,7 @@ when cpuX86 and canUseIntrinsics:
     {.pragma: x86_header, header: "<x86intrin.h>", nodecl.}
 
   func builtinCarryingAdd*(
-    carryIn: uint8, a, b: cuint, res: ptr cuint
+    carry: uint8, a, b: cuint, res: ptr cuint
   ): uint8 {.importc: "_addcarry_u32", x86_header.}
 
   func builtinBorrowingSub*(
@@ -27,11 +27,11 @@ when cpuX86 and canUseIntrinsics:
 
   {.push raises: [], inline, noinit, gcsafe.}
 
-  func carryingAdd*(a, b: uint32, carryIn: bool): (uint32, bool) =
+  func carryingAdd*(a, b: uint32, carry: bool): (uint32, bool) =
     var res {.noinit.}: uint32
 
     let carryOut =
-      builtinCarryingAdd(uint8(carryIn), cuint(a), cuint(b), cast[ptr cuint](addr res))
+      builtinCarryingAdd(uint8(carry), cuint(a), cuint(b), cast[ptr cuint](addr res))
 
     (res, bool(carryOut))
 
@@ -46,7 +46,7 @@ when cpuX86 and canUseIntrinsics:
 
 when cpu64bit and cpuX86 and canUseIntrinsics:
   func builtinCarryingAdd*(
-    carryIn: uint8, a, b: culonglong, res: ptr culonglong
+    carry: uint8, a, b: culonglong, res: ptr culonglong
   ): uint8 {.importc: "_addcarry_u64", x86_header.}
 
   func builtinBorrowingSub*(
@@ -55,11 +55,11 @@ when cpu64bit and cpuX86 and canUseIntrinsics:
 
   {.push raises: [], inline, noinit, gcsafe.}
 
-  func carryingAdd*(a, b: uint64, carryIn: bool): (uint64, bool) =
+  func carryingAdd*(a, b: uint64, carry: bool): (uint64, bool) =
     var res {.noinit.}: uint64
 
     let carryOut = builtinCarryingAdd(
-      uint8(carryIn), culonglong(a), culonglong(b), cast[ptr culonglong](addr res)
+      uint8(carry), culonglong(a), culonglong(b), cast[ptr culonglong](addr res)
     )
 
     (res, bool(carryOut))

--- a/src/intops/impl/intrinsics/x86.nim
+++ b/src/intops/impl/intrinsics/x86.nim
@@ -38,10 +38,10 @@ when cpuX86 and canUseIntrinsics:
   func borrowingSub*(a, b: uint32, borrow: bool): (uint32, bool) =
     var res {.noinit.}: uint32
 
-    let borrowOut =
+    let borrow =
       builtinBorrowingSub(uint8(borrow), cuint(a), cuint(b), cast[ptr cuint](addr res))
 
-    (res, bool(borrowOut))
+    (res, bool(borrow))
 
 when cpu64bit and cpuX86 and canUseIntrinsics:
   func builtinCarryingAdd*(
@@ -66,11 +66,11 @@ when cpu64bit and cpuX86 and canUseIntrinsics:
   func borrowingSub*(a, b: uint64, borrow: bool): (uint64, bool) =
     var res {.noinit.}: uint64
 
-    let borrowOut = builtinBorrowingSub(
+    let borrow = builtinBorrowingSub(
       uint8(borrow), culonglong(a), culonglong(b), cast[ptr culonglong](addr res)
     )
 
-    (res, bool(borrowOut))
+    (res, bool(borrow))
 
 when cpu64bit and cpuX86 and compilerMsvc and canUseIntrinsics:
   func builtinWideningMul*(

--- a/src/intops/impl/intrinsics/x86.nim
+++ b/src/intops/impl/intrinsics/x86.nim
@@ -22,7 +22,7 @@ when cpuX86 and canUseIntrinsics:
   ): uint8 {.importc: "_addcarry_u32", x86_header.}
 
   func builtinBorrowingSub*(
-    borrowIn: uint8, a, b: cuint, res: ptr uint32
+    borrow: uint8, a, b: cuint, res: ptr uint32
   ): uint8 {.importc: "_subborrow_u32", x86_header.}
 
   {.push raises: [], inline, noinit, gcsafe.}
@@ -35,12 +35,11 @@ when cpuX86 and canUseIntrinsics:
 
     (res, bool(carry))
 
-  func borrowingSub*(a, b: uint32, borrowIn: bool): (uint32, bool) =
+  func borrowingSub*(a, b: uint32, borrow: bool): (uint32, bool) =
     var res {.noinit.}: uint32
 
-    let borrowOut = builtinBorrowingSub(
-      uint8(borrowIn), cuint(a), cuint(b), cast[ptr cuint](addr res)
-    )
+    let borrowOut =
+      builtinBorrowingSub(uint8(borrow), cuint(a), cuint(b), cast[ptr cuint](addr res))
 
     (res, bool(borrowOut))
 
@@ -50,7 +49,7 @@ when cpu64bit and cpuX86 and canUseIntrinsics:
   ): uint8 {.importc: "_addcarry_u64", x86_header.}
 
   func builtinBorrowingSub*(
-    borrowIn: uint8, a, b: culonglong, res: ptr culonglong
+    borrow: uint8, a, b: culonglong, res: ptr culonglong
   ): uint8 {.importc: "_subborrow_u64", x86_header.}
 
   {.push raises: [], inline, noinit, gcsafe.}
@@ -64,11 +63,11 @@ when cpu64bit and cpuX86 and canUseIntrinsics:
 
     (res, bool(carry))
 
-  func borrowingSub*(a, b: uint64, borrowIn: bool): (uint64, bool) =
+  func borrowingSub*(a, b: uint64, borrow: bool): (uint64, bool) =
     var res {.noinit.}: uint64
 
     let borrowOut = builtinBorrowingSub(
-      uint8(borrowIn), culonglong(a), culonglong(b), cast[ptr culonglong](addr res)
+      uint8(borrow), culonglong(a), culonglong(b), cast[ptr culonglong](addr res)
     )
 
     (res, bool(borrowOut))

--- a/src/intops/impl/pure.nim
+++ b/src/intops/impl/pure.nim
@@ -79,19 +79,19 @@ func overflowingSub*[T: SomeSignedInt](a, b: T): (T, bool) =
 
   (res, didOverflow)
 
-func borrowingSub*[T: SomeUnsignedInt](a, b: T, borrowIn: bool): (T, bool) =
+func borrowingSub*[T: SomeUnsignedInt](a, b: T, borrow: bool): (T, bool) =
   let
     diff = a - b
     b1 = a < b
-    res = diff - T(borrowIn)
-    b2 = diff < T(borrowIn)
+    res = diff - T(borrow)
+    b2 = diff < T(borrow)
 
   (res, b1 or b2)
 
-func borrowingSub*[T: SomeSignedInt](a, b: T, borrowIn: bool): (T, bool) =
+func borrowingSub*[T: SomeSignedInt](a, b: T, borrow: bool): (T, bool) =
   let
     (diff1, o1) = pure.overflowingSub(a, b)
-    (final, o2) = pure.overflowingSub(diff1, T(borrowIn))
+    (final, o2) = pure.overflowingSub(diff1, T(borrow))
 
   (final, o1 or o2)
 

--- a/src/intops/impl/pure.nim
+++ b/src/intops/impl/pure.nim
@@ -44,8 +44,8 @@ func carryingAdd*[T: SomeSignedInt](a, b: T, carry: bool): (T, bool) =
   (final, o1 or o2)
 
 func carry*[T: SomeInteger](a, b: T, carry: bool): bool =
-  let (sum, o1) = pure.overflowingAdd(a, b)
-  o1 or (carry and (sum == high(T)))
+  let (res, didOverflow) = pure.overflowingAdd(a, b)
+  didOverflow or (carry and (res == high(T)))
 
 func saturatingAdd*[T: SomeUnsignedInt](a, b: T): T =
   let (res, didOverflow) = pure.overflowingAdd(a, b)
@@ -97,8 +97,8 @@ func borrowingSub*[T: SomeSignedInt](a, b: T, borrow: bool): (T, bool) =
   (final, o1 or o2)
 
 func borrow*[T: SomeInteger](a, b: T, borrow: bool): bool =
-  let (diff, o1) = pure.overflowingSub(a, b)
-  o1 or (borrow and (diff == low(T)))
+  let (res, didOverflow) = pure.overflowingSub(a, b)
+  didOverflow or (borrow and (res == low(T)))
 
 func saturatingSub*[T: SomeUnsignedInt](a, b: T): T =
   let (res, didBorrow) = pure.overflowingSub(a, b)

--- a/src/intops/impl/pure.nim
+++ b/src/intops/impl/pure.nim
@@ -27,19 +27,19 @@ func overflowingAdd*[T: SomeSignedInt](a, b: T): (T, bool) =
 
   (res, didOverflow)
 
-func carryingAdd*[T: SomeUnsignedInt](a, b: T, carryIn: bool): (T, bool) =
+func carryingAdd*[T: SomeUnsignedInt](a, b: T, carry: bool): (T, bool) =
   let
     sum = a + b
     c1 = sum < a
-    res = sum + T(carryIn)
+    res = sum + T(carry)
     c2 = res < sum
 
   (res, c1 or c2)
 
-func carryingAdd*[T: SomeSignedInt](a, b: T, carryIn: bool): (T, bool) =
+func carryingAdd*[T: SomeSignedInt](a, b: T, carry: bool): (T, bool) =
   let
     (sum1, o1) = pure.overflowingAdd(a, b)
-    (final, o2) = pure.overflowingAdd(sum1, T(carryIn))
+    (final, o2) = pure.overflowingAdd(sum1, T(carry))
 
   (final, o1 or o2)
 

--- a/src/intops/impl/pure.nim
+++ b/src/intops/impl/pure.nim
@@ -43,8 +43,9 @@ func carryingAdd*[T: SomeSignedInt](a, b: T, carry: bool): (T, bool) =
 
   (final, o1 or o2)
 
-func carry*(a, b: SomeInteger, carry: bool): bool =
-  pure.carryingAdd(a, b, carry)[1]
+func carry*[T: SomeInteger](a, b: T, carry: bool): bool =
+  let (sum, o1) = pure.overflowingAdd(a, b)
+  o1 or (carry and (sum == high(T)))
 
 func saturatingAdd*[T: SomeUnsignedInt](a, b: T): T =
   let (res, didOverflow) = pure.overflowingAdd(a, b)
@@ -95,8 +96,9 @@ func borrowingSub*[T: SomeSignedInt](a, b: T, borrow: bool): (T, bool) =
 
   (final, o1 or o2)
 
-func borrow*(a, b: SomeInteger, borrow: bool): bool =
-  pure.borrowingSub(a, b, borrow)[1]
+func borrow*[T: SomeInteger](a, b: T, borrow: bool): bool =
+  let (diff, o1) = pure.overflowingSub(a, b)
+  o1 or (borrow and (diff == low(T)))
 
 func saturatingSub*[T: SomeUnsignedInt](a, b: T): T =
   let (res, didBorrow) = pure.overflowingSub(a, b)

--- a/src/intops/impl/pure.nim
+++ b/src/intops/impl/pure.nim
@@ -43,6 +43,9 @@ func carryingAdd*[T: SomeSignedInt](a, b: T, carryIn: bool): (T, bool) =
 
   (final, o1 or o2)
 
+func carry*(a, b: SomeInteger, carry: bool): bool =
+  pure.carryingAdd(a, b, carry)[1]
+
 func saturatingAdd*[T: SomeUnsignedInt](a, b: T): T =
   let (res, didOverflow) = pure.overflowingAdd(a, b)
 
@@ -91,6 +94,9 @@ func borrowingSub*[T: SomeSignedInt](a, b: T, borrowIn: bool): (T, bool) =
     (final, o2) = pure.overflowingSub(diff1, T(borrowIn))
 
   (final, o1 or o2)
+
+func borrow*(a, b: SomeInteger, borrow: bool): bool =
+  pure.borrowingSub(a, b, borrow)[1]
 
 func saturatingSub*[T: SomeUnsignedInt](a, b: T): T =
   let (res, didBorrow) = pure.overflowingSub(a, b)

--- a/src/intops/impl/pure.nim
+++ b/src/intops/impl/pure.nim
@@ -205,7 +205,7 @@ func wideningMulAdd*(a, b, c: uint64): (uint64, uint64) =
     (prodHi, prodLo) = wideningMul(a, b)
     (sumLo, carry) = carryingAdd(prodLo, c, false)
     lo = sumLo
-    hi = prodHi + (if carry: 1'u64 else: 0'u64)
+    hi = prodHi + uint64(carry)
 
   (hi, lo)
 
@@ -229,7 +229,7 @@ func wideningMulAdd*(a, b, c, d: uint64): (uint64, uint64) =
     (sumLo1, carry1) = carryingAdd(prodLo, c, false)
     (sumLo2, carry2) = carryingAdd(sumLo1, d, false)
     lo = sumLo2
-    hi = prodHi + (if carry1: 1'u64 else: 0'u64) + (if carry2: 1'u64 else: 0'u64)
+    hi = prodHi + uint64(carry1) + uint64(carry2)
 
   (hi, lo)
 

--- a/src/intops/ops/add.nim
+++ b/src/intops/ops/add.nim
@@ -137,3 +137,6 @@ template carryingAdd*(a, b: int32, carryIn: bool): tuple[res: int32, carryOut: b
       intrinsics.gcc.carryingAdd(a, b, carryIn)
     else:
       pure.carryingAdd(a, b, carryIn)
+
+template getCarry*[T: SomeInteger](a, b: T, carryIn: bool): bool =
+  add.carryingAdd(a, b, carryIn).carryOut

--- a/src/intops/ops/add.nim
+++ b/src/intops/ops/add.nim
@@ -73,7 +73,6 @@ template carryingAdd*(a, b: uint64, carry: bool): tuple[res: uint64, carry: bool
     elif cpu64Bit and compilerGccCompatible and canUseInlineC:
       inlinec.carryingAdd(a, b, carry)
     else:
-      # Universal fallback
       pure.carryingAdd(a, b, carry)
 
 template carryingAdd*(a, b: uint32, carry: bool): tuple[res: uint32, carry: bool] =

--- a/src/intops/ops/add.nim
+++ b/src/intops/ops/add.nim
@@ -137,11 +137,34 @@ template carryingAdd*(a, b: int32, carry: bool): tuple[res: int32, carry: bool] 
     else:
       pure.carryingAdd(a, b, carry)
 
-template carry*[T: SomeInteger](a, b: T, carry: bool): bool =
-  ##[ Carrying addition that returns just the carry flag.
+template carry*(a, b: SomeUnsignedInt, carry: bool): bool =
+  ##[ Carrying addition that returns just the carry flag for unsigned integers.
 
   See also:
   - `carryingAdd`_
   ]##
 
-  pure.carry(a, b, carry)
+  when nimvm:
+    pure.carry(a, b, carry)
+  else:
+    when cpuX86 and compilerMsvc and canUseIntrinsics:
+      intrinsics.x86.carry(a, b, carry)
+    elif compilerGccCompatible and canUseIntrinsics:
+      intrinsics.gcc.carry(a, b, carry)
+    else:
+      pure.carry(a, b, carry)
+
+template carry*(a, b: SomeSignedInt, carry: bool): bool =
+  ##[ Carrying addition that returns just the carry flag for signed integers.
+
+  See also:
+  - `carryingAdd`_
+  ]##
+
+  when nimvm:
+    pure.carry(a, b, carry)
+  else:
+    when compilerGccCompatible and canUseIntrinsics:
+      intrinsics.gcc.carry(a, b, carry)
+    else:
+      pure.carry(a, b, carry)

--- a/src/intops/ops/add.nim
+++ b/src/intops/ops/add.nim
@@ -51,7 +51,7 @@ template saturatingAdd*[T: SomeInteger](a, b: T): T =
     else:
       pure.saturatingAdd(a, b)
 
-template carryingAdd*(a, b: uint64, carryIn: bool): tuple[res: uint64, carryOut: bool] =
+template carryingAdd*(a, b: uint64, carry: bool): tuple[res: uint64, carryOut: bool] =
   ##[ Carrying addition for unsigned 64-bit integers.
 
   Takes two integers and returns their sum along with the carrying flag (CF): 
@@ -64,19 +64,19 @@ template carryingAdd*(a, b: uint64, carryIn: bool): tuple[res: uint64, carryOut:
   ]##
 
   when nimvm:
-    pure.carryingAdd(a, b, carryIn)
+    pure.carryingAdd(a, b, carry)
   else:
     when cpuX86 and compilerMsvc and canUseIntrinsics:
-      intrinsics.x86.carryingAdd(a, b, carryIn)
+      intrinsics.x86.carryingAdd(a, b, carry)
     elif compilerGccCompatible and canUseIntrinsics:
-      intrinsics.gcc.carryingAdd(a, b, carryIn)
+      intrinsics.gcc.carryingAdd(a, b, carry)
     elif cpu64Bit and compilerGccCompatible and canUseInlineC:
-      inlinec.carryingAdd(a, b, carryIn)
+      inlinec.carryingAdd(a, b, carry)
     else:
       # Universal fallback
-      pure.carryingAdd(a, b, carryIn)
+      pure.carryingAdd(a, b, carry)
 
-template carryingAdd*(a, b: uint32, carryIn: bool): tuple[res: uint32, carryOut: bool] =
+template carryingAdd*(a, b: uint32, carry: bool): tuple[res: uint32, carryOut: bool] =
   ##[ Carrying addition for unsigned 32-bit integers.
 
   Takes two integers and returns their sum along with the carrying flag (CF): 
@@ -89,16 +89,16 @@ template carryingAdd*(a, b: uint32, carryIn: bool): tuple[res: uint32, carryOut:
   ]##
 
   when nimvm:
-    pure.carryingAdd(a, b, carryIn)
+    pure.carryingAdd(a, b, carry)
   else:
     when cpuX86 and compilerMsvc and canUseIntrinsics:
-      intrinsics.x86.carryingAdd(a, b, carryIn)
+      intrinsics.x86.carryingAdd(a, b, carry)
     elif compilerGccCompatible and canUseIntrinsics:
-      intrinsics.gcc.carryingAdd(a, b, carryIn)
+      intrinsics.gcc.carryingAdd(a, b, carry)
     else:
-      pure.carryingAdd(a, b, carryIn)
+      pure.carryingAdd(a, b, carry)
 
-template carryingAdd*(a, b: int64, carryIn: bool): tuple[res: int64, carryOut: bool] =
+template carryingAdd*(a, b: int64, carry: bool): tuple[res: int64, carryOut: bool] =
   ##[ Carrying addition for signed 64-bit integers.
 
   Takes two integers and returns their sum along with the carrying flag (CF): 
@@ -111,14 +111,14 @@ template carryingAdd*(a, b: int64, carryIn: bool): tuple[res: int64, carryOut: b
   ]##
 
   when nimvm:
-    pure.carryingAdd(a, b, carryIn)
+    pure.carryingAdd(a, b, carry)
   else:
     when compilerGccCompatible and canUseIntrinsics:
-      intrinsics.gcc.carryingAdd(a, b, carryIn)
+      intrinsics.gcc.carryingAdd(a, b, carry)
     else:
-      pure.carryingAdd(a, b, carryIn)
+      pure.carryingAdd(a, b, carry)
 
-template carryingAdd*(a, b: int32, carryIn: bool): tuple[res: int32, carryOut: bool] =
+template carryingAdd*(a, b: int32, carry: bool): tuple[res: int32, carryOut: bool] =
   ##[ Carrying addition for signed 32-bit integers.
 
   Takes two integers and returns their sum along with the carrying flag (CF): 
@@ -131,12 +131,12 @@ template carryingAdd*(a, b: int32, carryIn: bool): tuple[res: int32, carryOut: b
   ]##
 
   when nimvm:
-    pure.carryingAdd(a, b, carryIn)
+    pure.carryingAdd(a, b, carry)
   else:
     when compilerGccCompatible and canUseIntrinsics:
-      intrinsics.gcc.carryingAdd(a, b, carryIn)
+      intrinsics.gcc.carryingAdd(a, b, carry)
     else:
-      pure.carryingAdd(a, b, carryIn)
+      pure.carryingAdd(a, b, carry)
 
 template carry*[T: SomeInteger](a, b: T, carry: bool): bool =
   ##[ Carrying addition that returns just the carry flag.

--- a/src/intops/ops/add.nim
+++ b/src/intops/ops/add.nim
@@ -138,5 +138,11 @@ template carryingAdd*(a, b: int32, carryIn: bool): tuple[res: int32, carryOut: b
     else:
       pure.carryingAdd(a, b, carryIn)
 
-template getCarry*[T: SomeInteger](a, b: T, carryIn: bool): bool =
-  add.carryingAdd(a, b, carryIn).carryOut
+template carry*[T: SomeInteger](a, b: T, carry: bool): bool =
+  ##[ Carrying addition that returns just the carry flag.
+
+  See also:
+  - `carryingAdd`_
+  ]##
+
+  pure.carry(a, b, carry)

--- a/src/intops/ops/add.nim
+++ b/src/intops/ops/add.nim
@@ -51,7 +51,7 @@ template saturatingAdd*[T: SomeInteger](a, b: T): T =
     else:
       pure.saturatingAdd(a, b)
 
-template carryingAdd*(a, b: uint64, carry: bool): tuple[res: uint64, carryOut: bool] =
+template carryingAdd*(a, b: uint64, carry: bool): tuple[res: uint64, carry: bool] =
   ##[ Carrying addition for unsigned 64-bit integers.
 
   Takes two integers and returns their sum along with the carrying flag (CF): 
@@ -76,7 +76,7 @@ template carryingAdd*(a, b: uint64, carry: bool): tuple[res: uint64, carryOut: b
       # Universal fallback
       pure.carryingAdd(a, b, carry)
 
-template carryingAdd*(a, b: uint32, carry: bool): tuple[res: uint32, carryOut: bool] =
+template carryingAdd*(a, b: uint32, carry: bool): tuple[res: uint32, carry: bool] =
   ##[ Carrying addition for unsigned 32-bit integers.
 
   Takes two integers and returns their sum along with the carrying flag (CF): 
@@ -98,7 +98,7 @@ template carryingAdd*(a, b: uint32, carry: bool): tuple[res: uint32, carryOut: b
     else:
       pure.carryingAdd(a, b, carry)
 
-template carryingAdd*(a, b: int64, carry: bool): tuple[res: int64, carryOut: bool] =
+template carryingAdd*(a, b: int64, carry: bool): tuple[res: int64, carry: bool] =
   ##[ Carrying addition for signed 64-bit integers.
 
   Takes two integers and returns their sum along with the carrying flag (CF): 
@@ -118,7 +118,7 @@ template carryingAdd*(a, b: int64, carry: bool): tuple[res: int64, carryOut: boo
     else:
       pure.carryingAdd(a, b, carry)
 
-template carryingAdd*(a, b: int32, carry: bool): tuple[res: int32, carryOut: bool] =
+template carryingAdd*(a, b: int32, carry: bool): tuple[res: int32, carry: bool] =
   ##[ Carrying addition for signed 32-bit integers.
 
   Takes two integers and returns their sum along with the carrying flag (CF): 

--- a/src/intops/ops/sub.nim
+++ b/src/intops/ops/sub.nim
@@ -53,7 +53,7 @@ template saturatingSub*[T: SomeInteger](a, b: T): T =
 
 template borrowingSub*(
     a, b: uint64, borrow: bool
-): tuple[res: uint64, borrowOut: bool] =
+): tuple[res: uint64, borrow: bool] =
   ##[ Borrowing subtraction for unsigned 64-bit integers.
 
   Takes two integers and returns their difference along with the borrow flag (BF): 
@@ -79,7 +79,7 @@ template borrowingSub*(
 
 template borrowingSub*(
     a, b: uint32, borrow: bool
-): tuple[res: uint32, borrowOut: bool] =
+): tuple[res: uint32, borrow: bool] =
   ##[ Borrowing subtraction for unsigned 32-bit integers.
 
   Takes two integers and returns their difference along with the borrow flag (BF): 
@@ -103,7 +103,7 @@ template borrowingSub*(
 
 template borrowingSub*(
     a, b: int64, borrow: bool
-): tuple[res: int64, borrowOut: bool] =
+): tuple[res: int64, borrow: bool] =
   ##[ Borrowing subtraction for signed 64-bit integers.
 
   Takes two integers and returns their difference along with the borrow flag (BF):
@@ -125,7 +125,7 @@ template borrowingSub*(
 
 template borrowingSub*(
     a, b: int32, borrow: bool
-): tuple[res: int32, borrowOut: bool] =
+): tuple[res: int32, borrow: bool] =
   ##[ Borrowing subtraction for signed 32-bit integers.
 
   Takes two integers and returns their difference along with the borrow flag (BF): 

--- a/src/intops/ops/sub.nim
+++ b/src/intops/ops/sub.nim
@@ -123,7 +123,9 @@ template borrowingSub*(
     else:
       pure.borrowingSub(a, b, borrowIn)
 
-template borrowingSub*(a, b: int32, borrowIn: bool): (int32, bool) =
+template borrowingSub*(
+    a, b: int32, borrowIn: bool
+): tuple[res: int32, borrowOut: bool] =
   ##[ Borrowing subtraction for signed 32-bit integers.
 
   Takes two integers and returns their difference along with the borrow flag (BF): 
@@ -142,3 +144,6 @@ template borrowingSub*(a, b: int32, borrowIn: bool): (int32, bool) =
       intrinsics.gcc.borrowingSub(a, b, borrowIn)
     else:
       pure.borrowingSub(a, b, borrowIn)
+
+template getBorrow*[T: SomeInteger](a, b: T, borrowIn: bool): bool =
+  sub.borrowingSub(a, b, borrowIn).borrowOut

--- a/src/intops/ops/sub.nim
+++ b/src/intops/ops/sub.nim
@@ -137,11 +137,34 @@ template borrowingSub*(a, b: int32, borrow: bool): tuple[res: int32, borrow: boo
     else:
       pure.borrowingSub(a, b, borrow)
 
-template borrow*[T: SomeInteger](a, b: T, borrow: bool): bool =
-  ##[ Borrowing subtraction that returns just the borrow flag.
+template borrow*(a, b: SomeUnsignedInt, borrow: bool): bool =
+  ##[ Borrowing subtraction that returns just the borrow flag for unsigned integers.
 
   See also:
   - `borrowingSub`_
   ]##
 
-  pure.borrow(a, b, borrow)
+  when nimvm:
+    pure.borrow(a, b, borrow)
+  else:
+    when cpuX86 and compilerMsvc and canUseIntrinsics:
+      intrinsics.x86.borrow(a, b, borrow)
+    elif compilerGccCompatible and canUseIntrinsics:
+      intrinsics.gcc.borrow(a, b, borrow)
+    else:
+      pure.borrow(a, b, borrow)
+
+template borrow*(a, b: SomeSignedInt, borrow: bool): bool =
+  ##[ Borrowing subtraction that returns just the borrow flag for signed integers.
+
+  See also:
+  - `borrowingSub`_
+  ]##
+
+  when nimvm:
+    pure.borrow(a, b, borrow)
+  else:
+    when compilerGccCompatible and canUseIntrinsics:
+      intrinsics.gcc.borrow(a, b, borrow)
+    else:
+      pure.borrow(a, b, borrow)

--- a/src/intops/ops/sub.nim
+++ b/src/intops/ops/sub.nim
@@ -51,9 +51,7 @@ template saturatingSub*[T: SomeInteger](a, b: T): T =
     else:
       pure.saturatingSub(a, b)
 
-template borrowingSub*(
-    a, b: uint64, borrow: bool
-): tuple[res: uint64, borrow: bool] =
+template borrowingSub*(a, b: uint64, borrow: bool): tuple[res: uint64, borrow: bool] =
   ##[ Borrowing subtraction for unsigned 64-bit integers.
 
   Takes two integers and returns their difference along with the borrow flag (BF): 
@@ -77,9 +75,7 @@ template borrowingSub*(
     else:
       pure.borrowingSub(a, b, borrow)
 
-template borrowingSub*(
-    a, b: uint32, borrow: bool
-): tuple[res: uint32, borrow: bool] =
+template borrowingSub*(a, b: uint32, borrow: bool): tuple[res: uint32, borrow: bool] =
   ##[ Borrowing subtraction for unsigned 32-bit integers.
 
   Takes two integers and returns their difference along with the borrow flag (BF): 
@@ -101,9 +97,7 @@ template borrowingSub*(
     else:
       pure.borrowingSub(a, b, borrow)
 
-template borrowingSub*(
-    a, b: int64, borrow: bool
-): tuple[res: int64, borrow: bool] =
+template borrowingSub*(a, b: int64, borrow: bool): tuple[res: int64, borrow: bool] =
   ##[ Borrowing subtraction for signed 64-bit integers.
 
   Takes two integers and returns their difference along with the borrow flag (BF):
@@ -123,9 +117,7 @@ template borrowingSub*(
     else:
       pure.borrowingSub(a, b, borrow)
 
-template borrowingSub*(
-    a, b: int32, borrow: bool
-): tuple[res: int32, borrow: bool] =
+template borrowingSub*(a, b: int32, borrow: bool): tuple[res: int32, borrow: bool] =
   ##[ Borrowing subtraction for signed 32-bit integers.
 
   Takes two integers and returns their difference along with the borrow flag (BF): 

--- a/src/intops/ops/sub.nim
+++ b/src/intops/ops/sub.nim
@@ -52,7 +52,7 @@ template saturatingSub*[T: SomeInteger](a, b: T): T =
       pure.saturatingSub(a, b)
 
 template borrowingSub*(
-    a, b: uint64, borrowIn: bool
+    a, b: uint64, borrow: bool
 ): tuple[res: uint64, borrowOut: bool] =
   ##[ Borrowing subtraction for unsigned 64-bit integers.
 
@@ -66,19 +66,19 @@ template borrowingSub*(
   ]##
 
   when nimvm:
-    pure.borrowingSub(a, b, borrowIn)
+    pure.borrowingSub(a, b, borrow)
   else:
     when cpuX86 and compilerMsvc and canUseIntrinsics:
-      intrinsics.x86.borrowingSub(a, b, borrowIn)
+      intrinsics.x86.borrowingSub(a, b, borrow)
     elif compilerGccCompatible and canUseIntrinsics:
-      intrinsics.gcc.borrowingSub(a, b, borrowIn)
+      intrinsics.gcc.borrowingSub(a, b, borrow)
     elif cpu64Bit and compilerGccCompatible and canUseInlineC:
-      inlinec.borrowingSub(a, b, borrowIn)
+      inlinec.borrowingSub(a, b, borrow)
     else:
-      pure.borrowingSub(a, b, borrowIn)
+      pure.borrowingSub(a, b, borrow)
 
 template borrowingSub*(
-    a, b: uint32, borrowIn: bool
+    a, b: uint32, borrow: bool
 ): tuple[res: uint32, borrowOut: bool] =
   ##[ Borrowing subtraction for unsigned 32-bit integers.
 
@@ -92,17 +92,17 @@ template borrowingSub*(
   ]##
 
   when nimvm:
-    pure.borrowingSub(a, b, borrowIn)
+    pure.borrowingSub(a, b, borrow)
   else:
     when cpuX86 and compilerMsvc and canUseIntrinsics:
-      intrinsics.x86.borrowingSub(a, b, borrowIn)
+      intrinsics.x86.borrowingSub(a, b, borrow)
     elif compilerGccCompatible and canUseIntrinsics:
-      intrinsics.gcc.borrowingSub(a, b, borrowIn)
+      intrinsics.gcc.borrowingSub(a, b, borrow)
     else:
-      pure.borrowingSub(a, b, borrowIn)
+      pure.borrowingSub(a, b, borrow)
 
 template borrowingSub*(
-    a, b: int64, borrowIn: bool
+    a, b: int64, borrow: bool
 ): tuple[res: int64, borrowOut: bool] =
   ##[ Borrowing subtraction for signed 64-bit integers.
 
@@ -116,15 +116,15 @@ template borrowingSub*(
   ]##
 
   when nimvm:
-    pure.borrowingSub(a, b, borrowIn)
+    pure.borrowingSub(a, b, borrow)
   else:
     when compilerGccCompatible and canUseIntrinsics:
-      intrinsics.gcc.borrowingSub(a, b, borrowIn)
+      intrinsics.gcc.borrowingSub(a, b, borrow)
     else:
-      pure.borrowingSub(a, b, borrowIn)
+      pure.borrowingSub(a, b, borrow)
 
 template borrowingSub*(
-    a, b: int32, borrowIn: bool
+    a, b: int32, borrow: bool
 ): tuple[res: int32, borrowOut: bool] =
   ##[ Borrowing subtraction for signed 32-bit integers.
 
@@ -138,12 +138,12 @@ template borrowingSub*(
   ]##
 
   when nimvm:
-    pure.borrowingSub(a, b, borrowIn)
+    pure.borrowingSub(a, b, borrow)
   else:
     when compilerGccCompatible and canUseIntrinsics:
-      intrinsics.gcc.borrowingSub(a, b, borrowIn)
+      intrinsics.gcc.borrowingSub(a, b, borrow)
     else:
-      pure.borrowingSub(a, b, borrowIn)
+      pure.borrowingSub(a, b, borrow)
 
 template borrow*[T: SomeInteger](a, b: T, borrow: bool): bool =
   ##[ Borrowing subtraction that returns just he borrow flag.

--- a/src/intops/ops/sub.nim
+++ b/src/intops/ops/sub.nim
@@ -146,7 +146,7 @@ template borrowingSub*(
       pure.borrowingSub(a, b, borrow)
 
 template borrow*[T: SomeInteger](a, b: T, borrow: bool): bool =
-  ##[ Borrowing subtraction that returns just he borrow flag.
+  ##[ Borrowing subtraction that returns just the borrow flag.
 
   See also:
   - `borrowingSub`_

--- a/src/intops/ops/sub.nim
+++ b/src/intops/ops/sub.nim
@@ -145,5 +145,11 @@ template borrowingSub*(
     else:
       pure.borrowingSub(a, b, borrowIn)
 
-template getBorrow*[T: SomeInteger](a, b: T, borrowIn: bool): bool =
-  sub.borrowingSub(a, b, borrowIn).borrowOut
+template borrow*[T: SomeInteger](a, b: T, borrow: bool): bool =
+  ##[ Borrowing subtraction that returns just he borrow flag.
+
+  See also:
+  - `borrowingSub`_
+  ]##
+
+  pure.borrow(a, b, borrow)

--- a/tests/tintops.nim
+++ b/tests/tintops.nim
@@ -54,10 +54,10 @@ suite "Carrying and borrowing operations":
       check carryingAdd(high(T), high(T), true) == (high(T), true)
       check carryingAdd(high(T), high(T), false) == (high(T) - T(1), true)
 
-      check getCarry(high(T), low(T), true)
-      check not getCarry(high(T), low(T), false)
-      check getCarry(high(T), high(T), true)
-      check getCarry(high(T), high(T), false)
+      check carry(high(T), low(T), true)
+      check not carry(high(T), low(T), false)
+      check carry(high(T), high(T), true)
+      check carry(high(T), high(T), false)
 
     testCarryingAdd[uint32]()
     testCarryingAdd[uint64]()
@@ -67,8 +67,8 @@ suite "Carrying and borrowing operations":
       check carryingAdd(high(T), T(0), true) == (low(T), true)
       check carryingAdd(high(T), high(T), true) == (T(-1), true)
 
-      check getCarry(high(T), T(0), true)
-      check getCarry(high(T), high(T), true)
+      check carry(high(T), T(0), true)
+      check carry(high(T), high(T), true)
 
     testCarryingAdd[int32]()
     testCarryingAdd[int64]()
@@ -80,10 +80,10 @@ suite "Carrying and borrowing operations":
       check borrowingSub(low(T), high(T), true) == (low(T), true)
       check borrowingSub(low(T), high(T), false) == (low(T) + T(1), true)
 
-      check getBorrow(low(T), low(T), true)
-      check not getBorrow(low(T), low(T), false)
-      check getBorrow(low(T), high(T), true)
-      check getBorrow(low(T), high(T), false)
+      check borrow(low(T), low(T), true)
+      check not borrow(low(T), low(T), false)
+      check borrow(low(T), high(T), true)
+      check borrow(low(T), high(T), false)
 
     testBorrowingSub[uint32]()
     testBorrowingSub[uint64]()
@@ -93,8 +93,8 @@ suite "Carrying and borrowing operations":
       check borrowingSub(low(T), T(0), true) == (high(T), true)
       check borrowingSub(T(10), T(5), true) == (T(4), false)
 
-      check getBorrow(low(T), T(0), true)
-      check not getBorrow(T(10), T(5), true)
+      check borrow(low(T), T(0), true)
+      check not borrow(T(10), T(5), true)
 
     testBorrowingSub[int32]()
     testBorrowingSub[int64]()

--- a/tests/tintops.nim
+++ b/tests/tintops.nim
@@ -54,6 +54,11 @@ suite "Carrying and borrowing operations":
       check carryingAdd(high(T), high(T), true) == (high(T), true)
       check carryingAdd(high(T), high(T), false) == (high(T) - T(1), true)
 
+      check getCarry(high(T), low(T), true)
+      check not getCarry(high(T), low(T), false)
+      check getCarry(high(T), high(T), true)
+      check getCarry(high(T), high(T), false)
+
     testCarryingAdd[uint32]()
     testCarryingAdd[uint64]()
 
@@ -61,6 +66,9 @@ suite "Carrying and borrowing operations":
     template testCarryingAdd[T: SomeSignedInt]() =
       check carryingAdd(high(T), T(0), true) == (low(T), true)
       check carryingAdd(high(T), high(T), true) == (T(-1), true)
+
+      check getCarry(high(T), T(0), true)
+      check getCarry(high(T), high(T), true)
 
     testCarryingAdd[int32]()
     testCarryingAdd[int64]()
@@ -72,6 +80,11 @@ suite "Carrying and borrowing operations":
       check borrowingSub(low(T), high(T), true) == (low(T), true)
       check borrowingSub(low(T), high(T), false) == (low(T) + T(1), true)
 
+      check getBorrow(low(T), low(T), true)
+      check not getBorrow(low(T), low(T), false)
+      check getBorrow(low(T), high(T), true)
+      check getBorrow(low(T), high(T), false)
+
     testBorrowingSub[uint32]()
     testBorrowingSub[uint64]()
 
@@ -79,6 +92,9 @@ suite "Carrying and borrowing operations":
     template testBorrowingSub[T: SomeSignedInt]() =
       check borrowingSub(low(T), T(0), true) == (high(T), true)
       check borrowingSub(T(10), T(5), true) == (T(4), false)
+
+      check getBorrow(low(T), T(0), true)
+      check not getBorrow(T(10), T(5), true)
 
     testBorrowingSub[int32]()
     testBorrowingSub[int64]()


### PR DESCRIPTION
Closes #22 

I've researched the ways of calculating the carry flag without calculating the sum and it turns out calculating the sum and discarding the sum is the optimal solution.

I didn't want to put getCarry or getBorrow into composite.nim as those are not composite. But repeating the same `carryingAdd(a, b, carryIn).carryOut` for all implementations would be silly.

So my solution is to simply add the necessary logic directly into the dispatcher. This diverges from the original architecture where dispatchers are purely `when`-branches but I'd rather fix the docs and allow that than force a clumsy code pattern for the sake of purity.

The PR does not include benchmarks. This is because there are no implementations for `getCarry` or `getBorrow`, it's just sugar around `carryingAdd` and `borrowingSub`.